### PR TITLE
Feat: 정보 입력, 마이페이지 구현

### DIFF
--- a/src/main/java/com/hackathon/momento/auth/api/AuthController.java
+++ b/src/main/java/com/hackathon/momento/auth/api/AuthController.java
@@ -6,7 +6,6 @@ import com.hackathon.momento.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,9 +14,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Tag(name = "회원가입/로그인", description = "회원가입/로그인을 담당하는 api 그룹")
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "회원가입/로그인", description = "회원가입/로그인을 담당하는 API 그룹")
 public class AuthController {
 
     private final KakaoOauthService kakaoOAuthService;

--- a/src/main/java/com/hackathon/momento/global/config/SecurityConfig.java
+++ b/src/main/java/com/hackathon/momento/global/config/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
     private final String[] PERMIT_ALL_URLS = {
             "swagger-ui/**",
             "v3/api-docs/**",
-            "api/v1/auth/**"
+            "api/v1/auth/**",
+            "api/v1/member/**"
     };
 
     @Bean

--- a/src/main/java/com/hackathon/momento/member/api/MemberController.java
+++ b/src/main/java/com/hackathon/momento/member/api/MemberController.java
@@ -1,0 +1,43 @@
+package com.hackathon.momento.member.api;
+
+import com.hackathon.momento.global.template.RspTemplate;
+import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.application.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+@Tag(name = "사용자 정보", description = "사용자 정보를 담당하는 API 그룹")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PutMapping("/complete-profile")
+    @Operation(
+            summary = "최초 로그인 시 프로필 완성",
+            description = "최초 로그인 시 스택, 성격, 역량 정보를 입력받아 프로필을 완성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "프로필 완성 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            }
+    )
+    public RspTemplate<String> completeProfile(
+            Principal principal,
+            @Valid @RequestBody ProfileReqDto reqDto) {
+
+        memberService.completeProfile(principal, reqDto);
+        return new RspTemplate<>(HttpStatus.OK, "프로필이 성공적으로 완성되었습니다.");
+    }
+}

--- a/src/main/java/com/hackathon/momento/member/api/MemberController.java
+++ b/src/main/java/com/hackathon/momento/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.hackathon.momento.member.api;
 
 import com.hackathon.momento.global.template.RspTemplate;
 import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.api.dto.request.UpdateProfileReqDto;
 import com.hackathon.momento.member.api.dto.response.ProfileResDto;
 import com.hackathon.momento.member.application.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,7 +42,7 @@ public class MemberController {
             @Valid @RequestBody ProfileReqDto reqDto) {
 
         memberService.completeProfile(principal, reqDto);
-        return new RspTemplate<>(HttpStatus.OK, "프로필이 성공적으로 완성되었습니다.");
+        return new RspTemplate<>(HttpStatus.OK, "프로필 완성!");
     }
 
     @GetMapping("/profile")
@@ -56,5 +58,24 @@ public class MemberController {
     public RspTemplate<ProfileResDto> getProfile(Principal principal) {
         ProfileResDto profile = memberService.getProfile(principal);
         return new RspTemplate<>(HttpStatus.OK, "프로필 조회 성공", profile);
+    }
+
+    @PatchMapping("/update-profile")
+    @Operation(
+            summary = "프로필 수정",
+            description = "현재 로그인한 사용자의 프로필 정보를 수정합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            }
+    )
+    public RspTemplate<ProfileResDto> updateProfile(
+            Principal principal,
+            @Valid @RequestBody UpdateProfileReqDto reqDto) {
+
+        ProfileResDto updatedProfile = memberService.updateProfile(principal, reqDto);
+        return new RspTemplate<>(HttpStatus.OK, "프로필 수정 성공", updatedProfile);
     }
 }

--- a/src/main/java/com/hackathon/momento/member/api/MemberController.java
+++ b/src/main/java/com/hackathon/momento/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.hackathon.momento.member.api;
 
 import com.hackathon.momento.global.template.RspTemplate;
 import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.api.dto.response.ProfileResDto;
 import com.hackathon.momento.member.application.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +41,20 @@ public class MemberController {
 
         memberService.completeProfile(principal, reqDto);
         return new RspTemplate<>(HttpStatus.OK, "프로필이 성공적으로 완성되었습니다.");
+    }
+
+    @GetMapping("/profile")
+    @Operation(
+            summary = "프로필 조회",
+            description = "현재 로그인한 사용자의 프로필 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
+                    @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            }
+    )
+    public RspTemplate<ProfileResDto> getProfile(Principal principal) {
+        ProfileResDto profile = memberService.getProfile(principal);
+        return new RspTemplate<>(HttpStatus.OK, "프로필 조회 성공", profile);
     }
 }

--- a/src/main/java/com/hackathon/momento/member/api/dto/request/ProfileReqDto.java
+++ b/src/main/java/com/hackathon/momento/member/api/dto/request/ProfileReqDto.java
@@ -1,0 +1,15 @@
+package com.hackathon.momento.member.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProfileReqDto(
+        @NotBlank(message = "스택은 필수 입력 항목입니다")
+        String stack,
+
+        @NotBlank(message = "성격은 필수 입력 항목입니다")
+        String persona,
+
+        @NotBlank(message = "역량은 필수 입력 항목입니다")
+        String ability
+) {
+}

--- a/src/main/java/com/hackathon/momento/member/api/dto/request/UpdateProfileReqDto.java
+++ b/src/main/java/com/hackathon/momento/member/api/dto/request/UpdateProfileReqDto.java
@@ -1,0 +1,18 @@
+package com.hackathon.momento.member.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateProfileReqDto(
+        @NotBlank(message = "이름은 필수 입력 항목입니다")
+        String name,
+
+        @NotBlank(message = "스택은 필수 입력 항목입니다")
+        String stack,
+
+        @NotBlank(message = "성격은 필수 입력 항목입니다")
+        String persona,
+
+        @NotBlank(message = "역량은 필수 입력 항목입니다")
+        String ability
+) {
+}

--- a/src/main/java/com/hackathon/momento/member/api/dto/response/ProfileResDto.java
+++ b/src/main/java/com/hackathon/momento/member/api/dto/response/ProfileResDto.java
@@ -1,0 +1,23 @@
+package com.hackathon.momento.member.api.dto.response;
+
+import com.hackathon.momento.member.domain.Member;
+import lombok.Builder;
+
+@Builder
+public record ProfileResDto(
+        String email,
+        String name,
+        String stack,
+        String persona,
+        String ability
+) {
+    public static ProfileResDto from(Member member) {
+        return ProfileResDto.builder()
+                .email(member.getEmail())
+                .name(member.getName())
+                .stack(member.getStack())
+                .persona(member.getPersona())
+                .ability(member.getAbility())
+                .build();
+    }
+}

--- a/src/main/java/com/hackathon/momento/member/application/MemberService.java
+++ b/src/main/java/com/hackathon/momento/member/application/MemberService.java
@@ -21,9 +21,7 @@ public class MemberService {
 
     @Transactional
     public void completeProfile(Principal principal, ProfileReqDto reqDto) {
-        Long memberId = Long.parseLong(principal.getName());
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = getMemberByPrincipal(principal);
 
         if (!member.isFirstLogin()) {
             throw new FirstLoginOnlyException();
@@ -34,20 +32,22 @@ public class MemberService {
     }
 
     public ProfileResDto getProfile(Principal principal) {
-        Long memberId = Long.parseLong(principal.getName());
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = getMemberByPrincipal(principal);
 
         return ProfileResDto.from(member);
     }
 
     @Transactional
     public ProfileResDto updateProfile(Principal principal, UpdateProfileReqDto reqDto) {
-        Long memberId = Long.parseLong(principal.getName());
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
-
+        Member member = getMemberByPrincipal(principal);
         member.updateProfile(reqDto.name(), reqDto.stack(), reqDto.persona(), reqDto.ability());
+
         return ProfileResDto.from(member);
+    }
+
+    private Member getMemberByPrincipal(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/hackathon/momento/member/application/MemberService.java
+++ b/src/main/java/com/hackathon/momento/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.hackathon.momento.member.application;
 
 import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.api.dto.response.ProfileResDto;
 import com.hackathon.momento.member.domain.Member;
 import com.hackathon.momento.member.domain.repository.MemberRepository;
 import com.hackathon.momento.member.exception.FirstLoginOnlyException;
@@ -19,7 +20,7 @@ public class MemberService {
 
     @Transactional
     public void completeProfile(Principal principal, ProfileReqDto reqDto) {
-        Long memberId = Long.valueOf(principal.getName());
+        Long memberId = Long.parseLong(principal.getName());
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
@@ -29,5 +30,13 @@ public class MemberService {
 
         member.completeProfile(reqDto.stack(), reqDto.persona(), reqDto.ability());
         memberRepository.save(member);
+    }
+
+    public ProfileResDto getProfile(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return ProfileResDto.from(member);
     }
 }

--- a/src/main/java/com/hackathon/momento/member/application/MemberService.java
+++ b/src/main/java/com/hackathon/momento/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.hackathon.momento.member.application;
 
 import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.api.dto.request.UpdateProfileReqDto;
 import com.hackathon.momento.member.api.dto.response.ProfileResDto;
 import com.hackathon.momento.member.domain.Member;
 import com.hackathon.momento.member.domain.repository.MemberRepository;
@@ -37,6 +38,16 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
+        return ProfileResDto.from(member);
+    }
+
+    @Transactional
+    public ProfileResDto updateProfile(Principal principal, UpdateProfileReqDto reqDto) {
+        Long memberId = Long.parseLong(principal.getName());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        member.updateProfile(reqDto.name(), reqDto.stack(), reqDto.persona(), reqDto.ability());
         return ProfileResDto.from(member);
     }
 }

--- a/src/main/java/com/hackathon/momento/member/application/MemberService.java
+++ b/src/main/java/com/hackathon/momento/member/application/MemberService.java
@@ -1,0 +1,33 @@
+package com.hackathon.momento.member.application;
+
+import com.hackathon.momento.member.api.dto.request.ProfileReqDto;
+import com.hackathon.momento.member.domain.Member;
+import com.hackathon.momento.member.domain.repository.MemberRepository;
+import com.hackathon.momento.member.exception.FirstLoginOnlyException;
+import com.hackathon.momento.member.exception.MemberNotFoundException;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void completeProfile(Principal principal, ProfileReqDto reqDto) {
+        Long memberId = Long.valueOf(principal.getName());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        if (!member.isFirstLogin()) {
+            throw new FirstLoginOnlyException();
+        }
+
+        member.completeProfile(reqDto.stack(), reqDto.persona(), reqDto.ability());
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/hackathon/momento/member/domain/Member.java
+++ b/src/main/java/com/hackathon/momento/member/domain/Member.java
@@ -37,6 +37,8 @@ public class Member extends BaseEntity {
 
     private String ability;
 
+    private boolean isFirstLogin = true;
+
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
 
@@ -48,5 +50,12 @@ public class Member extends BaseEntity {
         this.persona = persona;
         this.ability = ability;
         this.roleType = roleType;
+    }
+
+    public void completeProfile(String stack, String persona, String ability) {
+        this.stack = stack;
+        this.persona = persona;
+        this.ability = ability;
+        this.isFirstLogin = false;
     }
 }

--- a/src/main/java/com/hackathon/momento/member/domain/Member.java
+++ b/src/main/java/com/hackathon/momento/member/domain/Member.java
@@ -58,4 +58,11 @@ public class Member extends BaseEntity {
         this.ability = ability;
         this.isFirstLogin = false;
     }
+
+    public void updateProfile(String name, String stack, String persona, String ability) {
+        this.name = name;
+        this.stack = stack;
+        this.persona = persona;
+        this.ability = ability;
+    }
 }

--- a/src/main/java/com/hackathon/momento/member/exception/FirstLoginOnlyException.java
+++ b/src/main/java/com/hackathon/momento/member/exception/FirstLoginOnlyException.java
@@ -1,0 +1,13 @@
+package com.hackathon.momento.member.exception;
+
+import com.hackathon.momento.global.error.exception.InvalidGroupException;
+
+public class FirstLoginOnlyException extends InvalidGroupException {
+    public FirstLoginOnlyException(String message) {
+        super(message);
+    }
+
+    public FirstLoginOnlyException() {
+        this("최초 로그인 시에만 설정할 수 있습니다.");
+    }
+}


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #7


## 🌱 작업 내용

- 최초 로그인 시 정보 `(스택, 역량, 성격)`를 입력받도록 구현
- 마이페이지 조회
- 마이페이지 수정

최초 프로필 등록
<img width="973" alt="최초 프로필 등록" src="https://github.com/user-attachments/assets/32c34984-c187-4d26-abde-0b716b21f701">

최초가 아닌 경우 오류
<img width="973" alt="최초가 아닌 경우" src="https://github.com/user-attachments/assets/885266e4-46ec-4f17-b42a-30117eb30864">

DB 반영
<img width="1294" alt="DB" src="https://github.com/user-attachments/assets/0181730e-2b8c-44bd-b774-96a948038ba3">

프로필 조회
<img width="973" alt="프로필 조회" src="https://github.com/user-attachments/assets/6dbfb275-4535-4838-807c-0cd0d8d2cb72">

프로필 업데이트
<img width="973" alt="프로필 업데이트" src="https://github.com/user-attachments/assets/c595a8bd-a22e-4289-afa1-391dd5b34b83">

DB 반영
<img width="1294" alt="DB_2" src="https://github.com/user-attachments/assets/7be1d0ce-03c7-4521-bc2a-777b9049f95e">


## 💬 리뷰 요구사항

