### PR TITLE
Feat: AI 팀 빌딩 중복 검사 구현

### DIFF
--- a/src/main/java/com/hackathon/momento/team/api/TeamController.java
+++ b/src/main/java/com/hackathon/momento/team/api/TeamController.java
@@ -75,4 +75,19 @@ public class TeamController {
         List<TeamInfoResDto> teamProfile = teamService.getTeamInfoProfile(TEMP_MEMBER_ID);
         return new RspTemplate<>(HttpStatus.OK, "팀 정보 조회 성공", teamProfile);
     }
+
+    @PostMapping("/check-duplicate")
+    @Operation(
+            summary = "AI 팀 빌딩 요청 중복 검사",
+            description = "사용자의 AI 팀 빌딩 요청이 존재하는지 여부를 검사합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "중복 검사 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            }
+    )
+    public RspTemplate<String> checkDuplicateRequest() {
+        boolean isDuplicate = teamService.checkDuplicate(TEMP_MEMBER_ID);
+        return new RspTemplate<>(HttpStatus.OK, String.valueOf(isDuplicate));
+    }
 }

--- a/src/main/java/com/hackathon/momento/team/application/TeamService.java
+++ b/src/main/java/com/hackathon/momento/team/application/TeamService.java
@@ -156,4 +156,11 @@ public class TeamService {
                 .map(TeamInfoResDto::from)
                 .collect(Collectors.toList());
     }
+
+    public boolean checkDuplicate(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return teamBuildingRepository.existsByMemberAndStatus(member, Status.PENDING);
+    }
 }


### PR DESCRIPTION
## 🍀 관련 이슈

- Resolved: #14 


## 🌱 작업 내용

- AI 팀 빌딩 중복 검사 구현

진행 중인 팀 빌딩이 존재할 시 `true`, 없다면 `false` 반환

<img width="1440" alt="스크린샷 2024-11-01 오후 8 07 21" src="https://github.com/user-attachments/assets/c28e3839-806c-4125-85e6-b63f103e9f56">

<img width="1440" alt="스크린샷 2024-11-01 오후 8 08 32" src="https://github.com/user-attachments/assets/d471e239-c599-4854-8f76-a430288ee97c">


## 💬 리뷰 요구사항
